### PR TITLE
Ag update nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,24 +9,22 @@ main_menu:
         url: /societal-impact/
       - title: "ukSRC Overview"
         submenu:
-        - title: "ukSRC Strategy"
-          url: /strategy/
-        - title: "Our Journey so far"
-          url: /history/
-        - title: "Collaborating Internationally"
-          url: /international/
-        - title: "Astronomy Community"
-          url: /astronomy-community/
+        - title: "What is ukSRC?"
+          url: /what-is-uksrc/
+        #- title: "Our Journey so far"
+         # url: /history/
+        - title: "Collaborations & Partners"
+          url: /collaborations/
         - title: "Technical Challenges"
           url: /technical-challenges/
-        - title: "Project Overview"
-          url: /project-overview/
+        # - title: "Project Overview"
+        #  url: /project-overview/
         - title: "Governance"
           url: /governance/
-      - title: "Linked Projects"
-        submenu:
-          - title: "FAIR Data Accelerator Pilot"
-            url: /fair-data-pilot/
+      #- title: "Linked Projects"
+       # submenu:
+        #  - title: "FAIR Data Accelerator Pilot"
+         #   url: /fair-data-pilot/
       - title: "Acknowledgement Statement"
         url: /acknowledgement/
   - title: "News & Events" 
@@ -42,6 +40,8 @@ main_menu:
             url: /webinar-series/
           - title: "Past Events"
             url: /past-events/
+  - title: "Astronomy Community"
+    url: /astronomy-community/
   - title: "Get involved"
     submenu:
       # - title: "Within SRC & SKAO"

--- a/_pages/collaborations.md
+++ b/_pages/collaborations.md
@@ -1,7 +1,7 @@
 ---
-title: "Collaborating internationally"
+title: "Collaborations & Partners"
 type: pages
-permalink: /international/
+permalink: /collaborations/
 layout: single
 header:
   overlay_image: /assets/images/SKA-at-Night.jpg

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -7,13 +7,20 @@ header:
   overlay_image: /assets/images/SKA-at-Night.jpg
   caption: "Image credit: SKAO"
 ---
+### User Support
+For all queries relating to scientific support and the use of ukSRC resources, please contact the [ukSRC User Support team](mailto:uksrc-support@manchester.ac.uk). 
 
-{% include contact_form.html %}
+### Adminstrative and Project Management
+For internal and external administrative matters, please contact the [ukSRC Project Office](mailto:uksrc-projectoffice@manchester.ac.uk).
+
+### Media
+For all media queries, please contact [Prof Rob Beswick and Dr Louise Chisholm](mailto:robert.beswick@manchester.ac.uk,l.chisholm@ucl.ac.uk), ukSRC Co-Directors. 
+
+
 
 Stay up to date and follow us:
 * Joint JISC mailing list with the STFC UK SKA Observatory Science Committee ​
 [UKSKA-SCIENCECOMMUNITY@JISCMAIL.AC.UK](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?A0=UKSKA-SCIENCECOMMUNITY)
-* [Twitter @UK_SKARC](https://twitter.com/UK_SKARC)
 * [Linked In](https://www.linkedin.com/company/uk-ska-regional-centre-uksrc)
 * [Zenodo community](https://zenodo.org/communities/uk_skarc/?page=1&size=20)
 * [ukSRC Webinar Series](https://www.uksrc.org/webinar-series/)

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -10,16 +10,8 @@ author_profile: false
 ---
 ## ukSRC Oversight Committee ##  
 Appointed by STFC, the ukSRC Oversight Committee provides independent advice, oversight and review of the ukSRC project on issues of risk and project cost, schedule and scope over the lifetime of the project. The ukSRC reports every 6 months to the OsC. 
-The members are Prof Ian Robson (Chair, University of Dundee); Dr Daniela Bauer (Imperial College London), Prof Peter Clarke (University of Edinburgh), Prof Melvin Hoare (University of Leeds), Dr Bob Jones (CERN), Anushka Sharma (University of Leicester) and Dr Sam Skipsey (University of Glasgow).  
+The OSC is chaired by Prof Ian Robson (University of Dundee).
 
 ## ukSRC Project Board ##  
 The Project Board provides external guidance and advice on scientific, technical and management matters related to the ukSRC project and monitors the delivery of the ukSRC project against the ukSRC Strategy. The ukSRC reports quarterly to the Project Board. 
-The members are Prof David Bacon (Chair, University of Portsmouth), Prof Simon McIntosh-Smith (Joint Lead ExCALIBUR hardware and Enabling Software Programme) and Dr Chiara Ferrari (Director of SKA-France), Prof Jon Hays (Science Director, IRIS), Andrew Sandsum (Technical Director, IRIS), Prof Mark Wilkinson (Director, DiRAC), and Christopher Walker (Research Support Senior Manager, JISC).     
-  
-## SKA Regional Centre Steering Committee (SRCSC) ##
-The mission of the SRCSC is to define and create a long-term operational partnership between the SKA Observatory and an ensemble of independently-resourced SKA Regional Centres. The SRCSC has participants taken from across the SKA membership, selected by each country to represent their national interests. The SRCSC will be superseded in due course by the operational partnership that is formed as a result of its work.
-
-
-
-
-
+The membership of the committee includes Prof David Bacon (Chair, University of Portsmouth), Dr Adrian Hinds (co-chair, NERC JASMIN Director) and Dr Chiara Ferrari (co-chair, Director of SKA-France). 

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -9,14 +9,6 @@ header:
 ---
 The ukSRC team brings together UK expertise in developing and delivering astronomy and digital research infrastructure.
 
-<br>
-The ukSRC partner institutes:
-
-
-{% include team_logos.html %}
-
-<br>
-
 ![ukSRC Team in front of the Lovell Telescope and SKAO Global HQ](/assets/images/teamphotos/UKSRC_Dec2024_2.png)
 *ukSRC Team, December 2024, in front of the Lovell Telescope and SKAO Global HQ*
 

--- a/_pages/what-is-uksrc.md
+++ b/_pages/what-is-uksrc.md
@@ -1,7 +1,7 @@
 ---
-title: "ukSRC Strategy"
+title: "What is ukSRC?"
 type: pages
-permalink: /strategy/
+permalink: /what-is-uksrc/
 layout: single
 header:
   overlay_image: /assets/images/SKA-at-Night.jpg


### PR DESCRIPTION
Team / ukSRC institutions 
Andrew - Change the order and layout of the content at the top to make it looks less like a footer.  

Strategy 
Andrew – rename to What is ukSRC 

“Our journey so far” 
Andrew – hide this for now, to be reincorporated somewhere else later

Astronomy Community 
This needs to be its own top-level section, on par with About, News etc.   

Project Overview 
Andrew – Very out of date and wrong, pull this now 

Governance 
Andrew - Remove SRCSC. Remove member names with the exception of chairs for OSC and PB. 

Contact page 
Remove form. Replace with descriptive text on who to contact for specific issues, uksrc-projectoffice, uksrc-support or individuals. 